### PR TITLE
Municipality browser restyling

### DIFF
--- a/data/public/css/browser.css
+++ b/data/public/css/browser.css
@@ -1,0 +1,18 @@
+html {
+   height: 100%;
+}
+
+body {
+  height: 100%;
+  flex-direction: column;
+  min-height: 100vh;
+  display: flex;
+}
+
+footer {
+  flex-shrink: 0;
+ }
+
+.futovac {
+  flex: 1;
+ }

--- a/data/public/css/custom.css
+++ b/data/public/css/custom.css
@@ -20,22 +20,22 @@ hr.dashed {
     width: 5%;
     margin-right:100%;
 }
-hr.baffone { 
-  height: 30px; 
-  border-style: solid; 
-  border-color: #8c8b8b; 
-  border-width: 1px 0 0 0; 
-  border-radius: 20px; 
-} 
-hr.baffone:before { 
-  display: block; 
-  content: ""; 
-  height: 30px; 
-  margin-top: -31px; 
-  border-style: solid; 
-  border-color: #8c8b8b; 
-  border-width: 0 0 1px 0; 
-  border-radius: 20px; 
+hr.baffone {
+  height: 30px;
+  border-style: solid;
+  border-color: #8c8b8b;
+  border-width: 1px 0 0 0;
+  border-radius: 20px;
+}
+hr.baffone:before {
+  display: block;
+  content: "";
+  height: 30px;
+  margin-top: -31px;
+  border-style: solid;
+  border-color: #8c8b8b;
+  border-width: 0 0 1px 0;
+  border-radius: 20px;
 }
 .moving {
   padding-top: 100px;

--- a/data/public/css/typeahead.css
+++ b/data/public/css/typeahead.css
@@ -1,0 +1,39 @@
+.tt-query {
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+     -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+          box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+}
+
+.tt-hint {
+  color: #999
+}
+
+.tt-menu {    /* used to be tt-dropdown-menu in older versions */
+  width: 422px;
+  margin-top: 4px;
+  padding: 4px 0;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  -webkit-border-radius: 4px;
+     -moz-border-radius: 4px;
+          border-radius: 4px;
+  -webkit-box-shadow: 0 5px 10px rgba(0,0,0,.2);
+     -moz-box-shadow: 0 5px 10px rgba(0,0,0,.2);
+          box-shadow: 0 5px 10px rgba(0,0,0,.2);
+}
+
+.tt-suggestion {
+  padding: 3px 20px;
+  line-height: 24px;
+}
+
+.tt-suggestion.tt-cursor,.tt-suggestion:hover {
+  color: #fff;
+  background-color: #0097cf;
+
+}
+
+.tt-suggestion p {
+  margin: 0;
+}

--- a/data/public/css/typeahead.css
+++ b/data/public/css/typeahead.css
@@ -37,3 +37,65 @@
 .tt-suggestion p {
   margin: 0;
 }
+
+
+/* SEARCH FORM */
+.form-control {
+    width: auto;
+    margin: 0 auto;
+}
+.rowS {
+    width: 100%;
+    text-align: center;
+    height: 150px;
+}
+
+.block {
+    display:inline-block;
+    float: left;
+}
+.searchBox {
+    width: 45%;
+}
+.vrblock {
+    width: 10%;
+    text-align: center;
+    position: relative;
+    height: 100%;
+}
+
+.line {
+    position: absolute;
+    left: 50%;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: #ccc;
+    z-index: 1;
+}
+
+.wordwrapper {
+    text-align: center;
+    height: 12px;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 50%;
+    margin-top: -12px;
+    z-index: 2;
+}
+
+.word {
+    color: #ccc;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    padding: 3px;
+    font: bold 12px arial,sans-serif;
+    background: #fff;
+}
+#searchByName {
+    padding: 15px 0 0 30px;
+}
+#searchByID {
+    padding: 15px 30px 0 0;
+}

--- a/data/public/municipality-browser/index.html
+++ b/data/public/municipality-browser/index.html
@@ -133,7 +133,7 @@
         </div>
 
         <br/><br/>
-        <div class="renderArea" resource="" context="zzm:HtmlBody">
+        <div class="renderArea" resource="" context="r2h:Default">
           <!--Municipality will appear here-->
         </div>
 

--- a/data/public/municipality-browser/index.html
+++ b/data/public/municipality-browser/index.html
@@ -12,6 +12,7 @@
         <script type="text/javascript" src="http://twitter.github.com/typeahead.js/releases/latest/typeahead.bundle.min.js"></script>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.6/css/bootstrap.min.css" type="text/css" />
         <link rel="stylesheet" href="/css/custom.css" />
+        <link rel="stylesheet" href="/css/browser.css" />
     </head>
     <body>
         <link rel="matchers" href="https://cdn.rawgit.com/rdf2h/rdf2h.github.io/v0.0.2/2015/rdf2h-points.ttl" type="text/turtle"/>
@@ -132,7 +133,11 @@
         </div>
 
         <br/><br/>
-        <div class="renderArea" resource="" context="zzm:HtmlBody">Municipality will appear here</div>
+        <div class="renderArea" resource="" context="zzm:HtmlBody">
+          <!--Municipality will appear here-->
+        </div>
+
+        <div class="futovac"></div>
 
         <div id="footer">
           Powered by <a href="https://github.com/zazukoians/trifid-ld" style="color:white">TRIFID-LD</a><br/>

--- a/data/public/municipality-browser/index.html
+++ b/data/public/municipality-browser/index.html
@@ -10,15 +10,16 @@
         <script src="https://cdn.rawgit.com/rdf2h/ld2h/v0.4.4/dist/ld2h.js"></script>
         <script src="//cdn.zazuko.com/retog/rdf-store-ldp-browser/v0.3.0-rc2f/dist/rdf-store-ldp.js"></script>
         <script type="text/javascript" src="http://twitter.github.com/typeahead.js/releases/latest/typeahead.bundle.min.js"></script>
+        <link href="/css/typeahead.css" rel="stylesheet" type="text/css">
     </head>
     <body>
         <link rel="matchers" href="https://cdn.rawgit.com/rdf2h/rdf2h.github.io/v0.0.2/2015/rdf2h-points.ttl" type="text/turtle"/>
         <link rel="matchers" href="/rdf2h/matchers.ttl" type="text/turtle" />
         <link rel="matchers" href="/rdf2h/site-matchers.ttl" type="text/turtle" />
-            
+
         <script>
         $(function () {
-            
+
             RDF2h.prefixMap["r2h"] = "http://rdf2h.github.io/2015/rdf2h#";
             RDF2h.prefixMap["zzm"] = "http://zz2h.zazukoians.org/modes/";
             RDF2h.prefixMap["dadmin"] = "http://data.admin.ch/rdf2h/matchers/";
@@ -36,8 +37,8 @@
                 LD2h.store = store;
                 window.ld2hRendered = LD2h.expand();
             }
-            
-            
+
+
             var bloodHound = new Bloodhound({
                 datumTokenizer: Bloodhound.tokenizers.obj.whitespace('value'),
                 queryTokenizer: Bloodhound.tokenizers.whitespace,
@@ -85,25 +86,25 @@
                             }
                         });
             });
-            
+
             $("#remote").keyup(function(event){
                 if(event.keyCode == 13){
                     $("#load").click();
                 }
             });
-            
+
 
             $("#load").on("click", function() {
                 renderMunicipality($("#text").val());
-                
+
             });
         });
         </script>
-        Find municipality by name: <input class="typeahead" type="text" placeholder="Municipality" id="municipalityName"><button id="find">Find</button><br/>
+        Find municipality by name: <input class="typeahead form-control" type="text" placeholder="Municipality" id="municipalityName"><button id="find">Find</button><br/>
         Enter municipality id: <input id="text" size="90" type="text" value="http://classifications.data.admin.ch/municipality/1" />
         <button id="load">Load</button><br/>
         <div class="renderArea" resource="" context="zzm:HtmlBody">Municipality will appear here</div>
-        
+
     </body>
     </body>
 </html>

--- a/data/public/municipality-browser/index.html
+++ b/data/public/municipality-browser/index.html
@@ -119,7 +119,7 @@
           <div id="searchByID" class="block searchBox">
             <h4>Enter municipality id</h4>
             <input class="form-control" id="text" size="50" type="text" value="http://classifications.data.admin.ch/municipality/1">
-            <button type="submit" class="btn btn-primary" id="load" style="margin-top:5px;>Load</button>
+            <button type="submit" class="btn btn-primary" id="load" style="margin-top:5px;">Load</button>
           </div>
         </div>
 

--- a/data/public/municipality-browser/index.html
+++ b/data/public/municipality-browser/index.html
@@ -11,7 +11,7 @@
         <script src="//cdn.zazuko.com/retog/rdf-store-ldp-browser/v0.3.0-rc2f/dist/rdf-store-ldp.js"></script>
         <script type="text/javascript" src="http://twitter.github.com/typeahead.js/releases/latest/typeahead.bundle.min.js"></script>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.6/css/bootstrap.min.css" type="text/css" />
-        <link href="/css/typeahead.css" rel="stylesheet" type="text/css">
+        <link rel="stylesheet" href="/css/custom.css" />
     </head>
     <body>
         <link rel="matchers" href="https://cdn.rawgit.com/rdf2h/rdf2h.github.io/v0.0.2/2015/rdf2h-points.ttl" type="text/turtle"/>
@@ -102,6 +102,14 @@
         });
         </script>
 
+        <div id="header">
+          <img src="/img/admin-logo.png" height="70px" align="left" vspace="15" hspace="10">
+          <p align="right">
+            <h2 align="right">data.admin.ch</h2>
+          </p>
+          <p align="right">Linked Data Pilot</p>
+        </div>
+
         <div id="searchZone" class="rowS">
           <div id="searchByName" class="block searchBox">
             <h4>Find municipality by name</h4>
@@ -126,6 +134,12 @@
         <br/><br/>
         <div class="renderArea" resource="" context="zzm:HtmlBody">Municipality will appear here</div>
 
-    </body>
+        <div id="footer">
+          Powered by <a href="https://github.com/zazukoians/trifid-ld" style="color:white">TRIFID-LD</a><br/>
+          Code on <a href="https://github.com/zazuko/data.admin.ch" style="color:white"><b>github</b></a>
+        </div>
+
+        <!-- This CSS must be here to not be overwritten by matchers.ttl -->
+        <link href="/css/typeahead.css" rel="stylesheet" type="text/css">
     </body>
 </html>

--- a/data/public/municipality-browser/index.html
+++ b/data/public/municipality-browser/index.html
@@ -10,6 +10,7 @@
         <script src="https://cdn.rawgit.com/rdf2h/ld2h/v0.4.4/dist/ld2h.js"></script>
         <script src="//cdn.zazuko.com/retog/rdf-store-ldp-browser/v0.3.0-rc2f/dist/rdf-store-ldp.js"></script>
         <script type="text/javascript" src="http://twitter.github.com/typeahead.js/releases/latest/typeahead.bundle.min.js"></script>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.6/css/bootstrap.min.css" type="text/css" />
         <link href="/css/typeahead.css" rel="stylesheet" type="text/css">
     </head>
     <body>
@@ -100,9 +101,29 @@
             });
         });
         </script>
-        Find municipality by name: <input class="typeahead form-control" type="text" placeholder="Municipality" id="municipalityName"><button id="find">Find</button><br/>
-        Enter municipality id: <input id="text" size="90" type="text" value="http://classifications.data.admin.ch/municipality/1" />
-        <button id="load">Load</button><br/>
+
+        <div id="searchZone" class="rowS">
+          <div id="searchByName" class="block searchBox">
+            <h4>Find municipality by name</h4>
+            <input class="typeahead form-control" size="50" type="text" placeholder="Municipality..." id="municipalityName">
+            <br/><button type="submit" class="btn btn-primary" id="find">Find</button>
+          </div>
+
+          <div id="divOr" class="block vrblock">
+            <div class="line"></div>
+            <div class="wordwrapper">
+                <div class="word">or</div>
+            </div>
+          </div>
+
+          <div id="searchByID" class="block searchBox">
+            <h4>Enter municipality id</h4>
+            <input class="form-control" id="text" size="50" type="text" value="http://classifications.data.admin.ch/municipality/1">
+            <button type="submit" class="btn btn-primary" id="load" style="margin-top:5px;>Load</button>
+          </div>
+        </div>
+
+        <br/><br/>
         <div class="renderArea" resource="" context="zzm:HtmlBody">Municipality will appear here</div>
 
     </body>

--- a/data/public/rdf2h/site-matchers.ttl
+++ b/data/public/rdf2h/site-matchers.ttl
@@ -42,7 +42,7 @@
       <link href="graph_files/main.css" media="screen, print" type="text/css" rel="stylesheet" />
       <link href="graph_files/98da0a4.css" media="screen, print" type="text/css" rel="stylesheet" />
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.6/css/bootstrap.min.css" type="text/css" />
-      <link rel="stylesheet" href="css/main.css" type="text/css" />      
+      <link rel="stylesheet" href="css/main.css" type="text/css" />
 '''
   ];
   r2h:before generic:htmlHead, <capsWebsite>.
@@ -315,11 +315,11 @@ r2hp:generic r2h:before <muniheader> .
 
 
 <versions> a r2h:Matcher ;
-    r2h:triplePattern [        
+    r2h:triplePattern [
         r2h:subject r2h:this;
         r2h:predicate gont:municipalityVersion;
     ];
-    r2h:template [ 
+    r2h:template [
         r2h:context r2h:Default;
         r2h:mustache '''
         {{{:continue}}}
@@ -338,7 +338,7 @@ r2hp:generic r2h:before <muniheader> .
                 <div id="allVersions">
                   {{#gont:municipalityVersion}}
                   <div class="mVersion" style="display:none">
-                    <span resource="{{.}}" context="mode:Details" 
+                    <span resource="{{.}}" context="mode:Details"
                     class="fetch">Municipality should appear here</span>
                   </div>
                   {{/gont:municipalityVersion}}
@@ -380,19 +380,19 @@ r2hp:generic r2h:before <muniheader> .
 
 
 [ a r2h:Matcher ;
-    r2h:triplePattern [      
+    r2h:triplePattern [
         r2h:subject r2h:this;
         r2h:predicate rdf:type;
         r2h:object gont:MunicipalityVersion
     ];
-    r2h:template [ 
+    r2h:template [
         r2h:context mode:Title;
         r2h:mustache '''{{gont:longName}}'''
     ];
-    r2h:template [ 
+    r2h:template [
         r2h:context mode:Details;
         r2h:mustache '''<h3>Details for: <span class="versionName">{{gont:longName}}</span></h3>
-        Admission date: <span resource="{{gont:admissionEvent}}" context="mode:DateOnly" 
+        Admission date: <span resource="{{gont:admissionEvent}}" context="mode:DateOnly"
             class="fetch admissionDate">admission date should appear here</span><br/>
         {{{:continue mode:loopholeCaps}}}
 '''
@@ -407,11 +407,11 @@ r2hp:generic r2h:before <muniheader> .
 <http://zazukoians.org/2016/generic-rdf2h-matchers/rdfTypes> r2h:before <endEscapeDadminCaps>.
 
 <endEscapeDadminCaps> a r2h:Matcher ;
-    r2h:triplePattern [        
+    r2h:triplePattern [
         r2h:subject r2h:this;
         r2h:predicate rdf:type;
     ];
-    r2h:template [ 
+    r2h:template [
         r2h:context mode:loopholeCaps;
         r2h:mustache '''
         {{{:continue r2h:Default}}}
@@ -420,12 +420,12 @@ r2hp:generic r2h:before <muniheader> .
     r2h:before <http://zazukoians.org/2016/generic-rdf2h-matchers/catchall>.
 
 [ a r2h:Matcher ;
-    r2h:triplePattern [      
+    r2h:triplePattern [
         r2h:subject r2h:this;
         r2h:predicate rdf:type;
         r2h:object gont:MunicipalityChangeEvent
     ];
-    r2h:template [ 
+    r2h:template [
         r2h:context mode:DateOnly;
         r2h:mustache '''{{gont:date}}'''
     ];
@@ -437,15 +437,15 @@ r2hp:generic r2h:before <muniheader> .
 r2hp:average r2h:before <dbpediaAbstract> .
 
 <dbpediaAbstract> a r2h:Matcher ;
-    r2h:triplePattern [        
+    r2h:triplePattern [
         r2h:subject r2h:this;
         r2h:predicate dbo:thumbnail;
     ];
-    r2h:triplePattern [        
+    r2h:triplePattern [
         r2h:subject r2h:this;
         r2h:predicate dbo:abstract;
     ];
-    r2h:template [ 
+    r2h:template [
         r2h:context r2h:Default;
         r2h:mustache '''
         <div id="dbpediaAbstract" style="width:95%; margin:0 auto; padding: 1em 0 2em; overflow:hidden;" >
@@ -497,11 +497,11 @@ r2hp:average r2h:before <dbpediaAbstract> .
     ]; r2h:before r2hp:generic.
 
 r2hp:specific r2h:before [ a r2h:Matcher ;
-    r2h:triplePattern [      
+    r2h:triplePattern [
         r2h:subject r2h:this;
         r2h:predicate gont:populationStatistics
     ];
-    r2h:template [ 
+    r2h:template [
         r2h:context r2h:Default;
         r2h:mustache '''
 {{{:continue}}}
@@ -519,11 +519,11 @@ r2hp:specific r2h:before [ a r2h:Matcher ;
 ].
 
 <pyramid> a r2h:Matcher ;
-    r2h:triplePattern [      
+    r2h:triplePattern [
         r2h:subject r2h:this;
         r2h:predicate gont:populationSegment
     ];
-    r2h:template [ 
+    r2h:template [
         r2h:context r2h:Default;
         r2h:mustache '''
             <script>
@@ -672,13 +672,22 @@ r2hp:specific r2h:before [ a r2h:Matcher ;
                             .attr('width', function(d) { return xScale(percentage(d.female)); })
                             .attr('height', yScale.rangeBand());
 
+                        leftBarGroup.append("text")
+                            .attr('transform', translation(pointA, 0) + 'scale(-1,1)')
+                            .attr("x", regionWidth/3)
+                            .text("Male");
+
+                        rightBarGroup.append("text")
+                            .attr("x", regionWidth/2)
+                            .text("Female");
+
 
                         // so sick of string concatenation for translations
                         function translation(x,y) {
                           return 'translate(' + x + ',' + y + ')';
                         }
                     };
-                    displayPyramid();    
+                    displayPyramid();
                 });
             </script>
 
@@ -687,11 +696,11 @@ r2hp:specific r2h:before [ a r2h:Matcher ;
     r2h:before <pyramidSorter>.
 
 <pyramidSorter> r2h:before [ a r2h:Matcher ;
-    r2h:triplePattern [      
+    r2h:triplePattern [
         r2h:subject r2h:this;
         r2h:predicate gont:populationSegment
     ];
-    r2h:template [ 
+    r2h:template [
         r2h:context r2h:Default;
         r2h:javaScript '''function(n) {
             var result = "";
@@ -710,18 +719,18 @@ r2hp:specific r2h:before [ a r2h:Matcher ;
 ].
 
 <segment> r2h:before [ a r2h:Matcher ;
-    r2h:triplePattern [      
+    r2h:triplePattern [
         r2h:subject r2h:this;
         r2h:predicate gont:toAge
     ];
-    r2h:template [ 
+    r2h:template [
         r2h:context r2h:Default;
         r2h:mustache '''
 <script>
 
 window.populationData.push({
-    group: '{{gont:fromAge}} - {{gont:toAge}}', 
-    male: {{gont:malePopulation}} , 
+    group: '{{gont:fromAge}} - {{gont:toAge}}',
+    male: {{gont:malePopulation}} ,
     female: {{gont:femalePopulation}}
 });
 </script>
@@ -729,4 +738,3 @@ window.populationData.push({
     ];
     r2h:before r2hp:specific;
 ].
-


### PR DESCRIPTION
[x] Make sure the autocompletion menu isn't transparent
Resolved creating a typeahead.css with all the configuration to have a standard autocompletion menu

[x] Label the age pyramid so one knows which side are males and which females
Resolved adding a text to the d3.js element representing the right and left area. For the left occured to mirroring the text.

[x] Make it more clear that one either enters a URI or searches for a municipality by name
Done providing a complete restyle of these two forms.

[x] Make sure the header (and footer) are there already with the form and the form field isn't above the header.
Done writing H/F code in the index.html and calling a different context as suggested. Moreover I've written new css (only for the empty page) for adjusting spacing.